### PR TITLE
UPDATE: Update markdownlint-cli and eslint-plugin-promise to latest versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
     "eslint-plugin-new-with-error": "3.1.0",
     "eslint-plugin-no-loops": "0.3.0",
     "eslint-plugin-prettier": "4.0.0",
-    "eslint-plugin-promise": "5.1.1",
+    "eslint-plugin-promise": "6.0.0",
     "eslint-plugin-react": "7.27.1",
     "eslint-plugin-react-hooks": "4.3.0",
     "eslint-plugin-security": "1.4.0",
-    "markdownlint-cli": "0.30.0",
+    "markdownlint-cli": "0.31.0",
     "npm-run-all": "4.1.5",
     "prettier": "2.4.1",
     "typescript": "4.5.2"


### PR DESCRIPTION
This PR updates the following:
* `markdownlint-cli` to 0.31.0 to eliminate some audit warnings
* `eslint-plugin-promise` to 6.0.0 to be fully compatible with `eslint` > 8