### PR TITLE
[v3.4.2]: Allow React function components to be defined using const

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 Chronological history of changes to the ESLint config.
 
-## [v3.4.1] - February 8, 2021
+## [v3.4.2] - February 28, 2022
+
+* Turned off `react/function-component-definition` rule to allow React function
+components to be defined using `const` and arrow functions.
+
+## [v3.4.1] - February 8, 2022
 
 * Upgraded `markdownlint-cli` to `0.31.0` to eliminate some audit warnings.
 * Upgraded `eslint-plugin-promise` to `6.0.0` to be fully compatible with

--- a/index.js
+++ b/index.js
@@ -136,6 +136,7 @@ module.exports = {
     'react-hooks/rules-of-hooks': 'error',
     'react/boolean-prop-naming': 'error',
     'react/destructuring-assignment': ['error', 'always'],
+    'react/function-component-definition': 'off',
     'react/jsx-filename-extension': [
       'warn',
       {

--- a/package.json
+++ b/package.json
@@ -80,5 +80,5 @@
     "test:lint:js": "eslint . --ext .js --quiet",
     "test:lint:md": "markdownlint README.md --config markdownlint.config.json"
   },
-  "version": "3.4.1"
+  "version": "3.4.2"
 }

--- a/package.json
+++ b/package.json
@@ -80,5 +80,5 @@
     "test:lint:js": "eslint . --ext .js --quiet",
     "test:lint:md": "markdownlint README.md --config markdownlint.config.json"
   },
-  "version": "3.4.2"
+  "version": "3.4.1"
 }


### PR DESCRIPTION
Turned off `react/function-component-definition` rule to allow React function components to be defined using `const` and arrow functions.